### PR TITLE
feat(core): Migrate the project from Minecraft 1.21 to 1.19.4 and downgrade the Java version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ dependencies {
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
     // Mod libraries
-	modImplementation include("me.lucko:fabric-permissions-api:${project.permissions_api_version}")
 }
 
 processResources {
@@ -39,12 +38,12 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	it.options.release = 21
+	it.options.release = 17
 }
 
 java {
-	sourceCompatibility = JavaVersion.VERSION_21
-	targetCompatibility = JavaVersion.VERSION_21
+	sourceCompatibility = JavaVersion.VERSION_17
+	targetCompatibility = JavaVersion.VERSION_17
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.11
+minecraft_version=1.19.4
 loader_version=0.18.4
 loom_version=1.14-SNAPSHOT
 
@@ -15,5 +15,4 @@ archives_base_name=shieldstun
 is_stable=true
 
 # Dependencies
-fabric_version=0.140.0+1.21.11
-permissions_api_version=0.6.1
+fabric_version=0.87.2+1.19.4

--- a/src/main/java/me/libreh/shieldstun/command/ShieldStunCommand.java
+++ b/src/main/java/me/libreh/shieldstun/command/ShieldStunCommand.java
@@ -5,16 +5,15 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.context.CommandContext;
 import me.libreh.shieldstun.config.ConfigManager;
 import me.libreh.shieldstun.util.GenericModInfo;
-import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.server.permissions.PermissionLevel;
 
 import static net.minecraft.commands.Commands.literal;
 
 public class ShieldStunCommand {
+    private static final int ADMIN_PERMISSION_LEVEL = 3;
     private static final Component STUNS_ARE = Component.literal("Stuns are ");
     private static final Component STUNS_HAVE = Component.literal("Stuns have been ");
     private static final Component ENABLED = Component.literal("enabled").withStyle(ChatFormatting.GREEN);
@@ -24,16 +23,16 @@ public class ShieldStunCommand {
         dispatcher.register(literal("shieldstun")
                 .executes(ShieldStunCommand::about)
                 .then(literal("reload")
-                        .requires(source -> Permissions.check(source, "shieldstun.reload", PermissionLevel.ADMINS))
+                        .requires(source -> source.hasPermission(ADMIN_PERMISSION_LEVEL))
                         .executes(context -> reloadConfig(context.getSource())))
                 .then(literal("status")
-                        .requires(source -> Permissions.check(source, "shieldstun.status", true))
+                        .requires(source -> source.hasPermission(0))
                         .executes(context -> stunStatus(context.getSource())))
                 .then(literal("enable")
-                        .requires(source -> Permissions.check(source, "shieldstun.enable", PermissionLevel.ADMINS))
+                        .requires(source -> source.hasPermission(ADMIN_PERMISSION_LEVEL))
                         .executes(context -> enableStuns(context.getSource())))
                 .then(literal("disable")
-                        .requires(source -> Permissions.check(source, "shieldstun.disable", PermissionLevel.ADMINS))
+                        .requires(source -> source.hasPermission(ADMIN_PERMISSION_LEVEL))
                         .executes(context -> disableStuns(context.getSource()))));
     }
 
@@ -41,7 +40,7 @@ public class ShieldStunCommand {
         CommandSourceStack source = context.getSource();
 
         for (var text : source.getEntity() instanceof ServerPlayer ? GenericModInfo.getAboutFull() : GenericModInfo.getAboutConsole()) {
-            source.sendSuccess(() -> text, false);
+            source.sendSuccess(text, false);
         }
 
         return 1;
@@ -49,7 +48,7 @@ public class ShieldStunCommand {
 
     private static int reloadConfig(CommandSourceStack source) {
         if (ConfigManager.load()) {
-            source.sendSuccess(() -> Component.literal("Reloaded config!"), false);
+            source.sendSuccess(Component.literal("Reloaded config!"), false);
         } else {
             source.sendFailure(Component.literal("Failed to reload the config! Check server console for more info.").withStyle(ChatFormatting.RED));
         }
@@ -64,7 +63,7 @@ public class ShieldStunCommand {
             status = DISABLED.copy();
         }
         Component message = STUNS_ARE.copy().append(status);
-        source.sendSuccess(() -> message, false);
+        source.sendSuccess(message, false);
         return Command.SINGLE_SUCCESS;
     }
 
@@ -72,7 +71,7 @@ public class ShieldStunCommand {
         ConfigManager.getConfig().enableStuns = true;
         ConfigManager.save();
         Component message = STUNS_HAVE.copy().append(ENABLED.copy());
-        source.sendSuccess(() -> message, false);
+        source.sendSuccess(message, false);
         return Command.SINGLE_SUCCESS;
     }
 
@@ -80,7 +79,7 @@ public class ShieldStunCommand {
         ConfigManager.getConfig().enableStuns = false;
         ConfigManager.save();
         Component message = STUNS_HAVE.copy().append(DISABLED.copy());
-        source.sendSuccess(() -> message, false);
+        source.sendSuccess(message, false);
         return Command.SINGLE_SUCCESS;
     }
 }

--- a/src/main/java/me/libreh/shieldstun/mixin/LivingEntityMixin.java
+++ b/src/main/java/me/libreh/shieldstun/mixin/LivingEntityMixin.java
@@ -4,7 +4,6 @@ import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import me.libreh.shieldstun.config.ConfigManager;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
@@ -23,15 +22,18 @@ public abstract class LivingEntityMixin extends Entity {
     @Unique
     private boolean blockedHit = false;
 
-    @WrapOperation(method = "hurtServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/LivingEntity;applyItemBlocking(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/damagesource/DamageSource;F)F"))
-    private float hurtServer(LivingEntity instance, ServerLevel serverLevel, DamageSource damageSource, float damageAmount, Operation<Float> original) {
-        float blockedAmount = original.call(instance, serverLevel, damageSource, damageAmount);
-        blockedHit = ConfigManager.getConfig().enableStuns && blockedAmount != 0.0F;
-        return blockedAmount;
+    @WrapOperation(
+            method = "hurt(Lnet/minecraft/world/damagesource/DamageSource;F)Z",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/LivingEntity;isDamageSourceBlocked(Lnet/minecraft/world/damagesource/DamageSource;)Z")
+    )
+    private boolean hurt(LivingEntity instance, DamageSource damageSource, Operation<Boolean> original) {
+        boolean blocked = original.call(instance, damageSource);
+        blockedHit = ConfigManager.getConfig().enableStuns && blocked;
+        return blocked;
     }
 
-    @ModifyReturnValue(method = "hurtServer", at = @At("RETURN"))
-    private boolean hurtServerReturn(boolean original) {
+    @ModifyReturnValue(method = "hurt(Lnet/minecraft/world/damagesource/DamageSource;F)Z", at = @At("RETURN"))
+    private boolean hurtReturn(boolean original) {
         if (blockedHit) {
             this.invulnerableTime = 0;
             return false;

--- a/src/main/java/me/libreh/shieldstun/mixin/PlayerMixin.java
+++ b/src/main/java/me/libreh/shieldstun/mixin/PlayerMixin.java
@@ -1,25 +1,21 @@
 package me.libreh.shieldstun.mixin;
 
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.component.BlocksAttacks;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Player.class)
 public abstract class PlayerMixin extends LivingEntity {
     protected PlayerMixin(EntityType<? extends @NotNull LivingEntity> entityType, Level level) { super(entityType, level); }
 
-    @WrapOperation(method = "blockUsingItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/component/BlocksAttacks;disable(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/entity/LivingEntity;FLnet/minecraft/world/item/ItemStack;)V"))
-    private void onShieldDisabled(BlocksAttacks instance, ServerLevel serverLevel, LivingEntity livingEntity, float f, ItemStack itemStack, Operation<Void> original) {
+    @Inject(method = "disableShield", at = @At("HEAD"))
+    private void onDisableShield(boolean byPlayer, CallbackInfo ci) {
         this.invulnerableTime = 20;
-        original.call(instance, serverLevel, livingEntity, f, itemStack);
     }
 }

--- a/src/main/java/me/libreh/shieldstun/util/GenericModInfo.java
+++ b/src/main/java/me/libreh/shieldstun/util/GenericModInfo.java
@@ -8,7 +8,6 @@ import org.slf4j.Logger;
 
 import javax.imageio.ImageIO;
 import java.io.FileNotFoundException;
-import java.net.URI;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
@@ -66,14 +65,14 @@ public class GenericModInfo {
                         runLength++;
                     } else {
                         line.append(Component.literal("█".repeat(runLength))
-                                .setStyle(Style.EMPTY.withColor(currentColor).withShadowColor(currentColor | 0xFF000000)));
+                                .setStyle(Style.EMPTY.withColor(currentColor)));
                         currentColor = pixelColor;
                         runLength = 1;
                     }
                 }
 
                 line.append(Component.literal("█".repeat(runLength))
-                        .setStyle(Style.EMPTY.withColor(currentColor).withShadowColor(currentColor | 0xFF000000)));
+                        .setStyle(Style.EMPTY.withColor(currentColor)));
                 iconLines.add(line);
             }
         } catch (Throwable e) {
@@ -99,27 +98,27 @@ public class GenericModInfo {
 
             var title = Component.literal(metadata.getName())
                     .setStyle(Style.EMPTY.withColor(titleColor).withBold(true)
-                            .withClickEvent(new ClickEvent.OpenUrl(URI.create(sources))));
+                            .withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, sources)));
 
             var versionUrl = hasSourcesUrl ? sources + "/releases/tag/" + versionString : sources;
             var version = Component.literal("Version: ").setStyle(Style.EMPTY.withColor(VERSION_LABEL_COLOR))
                     .append(Component.literal(versionString)
                             .setStyle(Style.EMPTY.withColor(ChatFormatting.WHITE)
-                                    .withClickEvent(new ClickEvent.OpenUrl(URI.create(versionUrl)))));
+                                    .withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, versionUrl))));
 
             var links = Component.literal("");
             if (showModrinth) {
                 var modrinthUrl = "https://modrinth.com/mod/" + id + "/version/" + versionString;
                 var modrinth = Component.literal("Modrinth")
                         .setStyle(Style.EMPTY.withColor(ChatFormatting.GREEN)
-                                .withClickEvent(new ClickEvent.OpenUrl(URI.create(modrinthUrl))));
+                                .withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, modrinthUrl)));
                 links.append(modrinth);
             }
 
             if (showGitHub) {
                 var github = Component.literal("GitHub")
                         .setStyle(Style.EMPTY.withColor(GITHUB_LINK_COLOR)
-                                .withClickEvent(new ClickEvent.OpenUrl(URI.create(sources))));
+                                .withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, sources)));
                 if (showModrinth) {
                     links.append(Component.literal(" • ").setStyle(Style.EMPTY.withColor(ChatFormatting.GRAY)));
                 }
@@ -144,14 +143,14 @@ public class GenericModInfo {
             var contributorsUrl = hasSourcesUrl ? sources + "/contributors" : sources;
             fullAbout.add(Component.literal("Contributors")
                     .setStyle(Style.EMPTY.withColor(ChatFormatting.AQUA)
-                            .withHoverEvent(new HoverEvent.ShowText(Component.literal(String.join(", ", contributors))))
-                            .withClickEvent(new ClickEvent.OpenUrl(URI.create(contributorsUrl)))));
+                            .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal(String.join(", ", contributors))))
+                            .withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, contributorsUrl))));
             fullAbout.add(Component.empty());
 
             var words = new ArrayList<>(List.of(metadata.getDescription().split(" ")));
             var line = new StringBuilder();
             while (!words.isEmpty()) {
-                (line.isEmpty() ? line : line.append(" ")).append(words.removeFirst());
+                (line.isEmpty() ? line : line.append(" ")).append(words.remove(0));
                 if (line.length() > 16) {
                     fullAbout.add(Component.literal(line.toString()).setStyle(Style.EMPTY.withColor(ChatFormatting.GRAY)));
                     line = new StringBuilder();

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,8 +24,8 @@
 	],
 	"depends": {
 		"fabricloader": ">=0.18",
-		"minecraft": "~1.21.10",
-		"java": ">=21",
+		"minecraft": "~1.19.4",
+		"java": ">=17",
 		"fabric-api": "*"
 	}
 }

--- a/src/main/resources/shieldstun.mixins.json
+++ b/src/main/resources/shieldstun.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "me.libreh.shieldstun.mixin",
-  "compatibilityLevel": "JAVA_21",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "LivingEntityMixin",
     "PlayerMixin"


### PR DESCRIPTION
- Remove the fabric-permissions-api dependency and related permission check code
- Downgrade Java compilation version from 21 to 17
- Downgrade Minecraft version from 1.21.11 to 1.19.4
- Modify Mixin injection points to adapt to the older Minecraft version
- Remove unsupported ShadowColor style settings
- Replace third-party permissions API with the standard permission system
- Fix method calls for sending command messages
- Simplify the implementation of player shield disable logic

Then I didn’t know how to create a 1.19.4 branch in your repository (maybe it’s not possible at all), so I chose to make a pull request to your 1.21.11 branch, hoping you can resolve it. XD